### PR TITLE
chore: Update to docker 29

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:28
+FROM docker:29
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Description

Docker 29 [was released yesterday](https://www.docker.com/blog/docker-engine-version-29/), so any VMs that updated to the new docker version will not work with docker 28 since the client version in the image is too old, resulting in this error:

```
docker: Error response from daemon: client version 1.40 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version.
```

## Testing

n/a

## References

n/a