### PR TITLE
chore: keep major version in line with released version

### DIFF
--- a/.github/workflows/update-major-version.yaml
+++ b/.github/workflows/update-major-version.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+# Copyright (c) 2021 Vincent A. Cicirello
+# MIT License
+---
+name: "Update Major Release Tag"
+
+on: # yamllint disable-line rule:truthy
+  release:
+    types: ["created"]
+
+jobs:
+  movetag:
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: "actions/checkout@v6"
+
+      - name: "Get major version num and update tag"
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/}
+          MAJOR=${VERSION%%.*}
+          git config --global user.name 'tstirrat15'
+          git config --global user.email 'tstirrat15@users.noreply.github.com'
+          git tag -fa "${MAJOR}" -m 'Update major version tag'
+          git push origin "${MAJOR}" --force


### PR DESCRIPTION
## Description
Most github actions are built to let you just specify the major version and let the rest of it float. I thought this was something built into how github actions works, but it turns out they just want you to keep the major tag updated in line with the normal semver.

This adds an action which will do that automatically when we update the version of this action.

## Changes
* Add a workflow to update the major tag when a version is released
## Testing
Review.